### PR TITLE
fix: declare: not found

### DIFF
--- a/kidreports-memories.sh
+++ b/kidreports-memories.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Set Your Start Month/Year and End Month/Year (no validation so please make sure it is accurate)
 declare -i START_MONTH=4


### PR DESCRIPTION
declare doesn't exist in sh, but in bash or zsh; fixing shebang to use bash as it's more common

thanks a lot for this clever script!